### PR TITLE
Flexible dice names

### DIFF
--- a/src/advancedRoller/advancedRoller.js
+++ b/src/advancedRoller/advancedRoller.js
@@ -50,6 +50,19 @@ class AdvancedRoller{
 		}
 	}
 	handleResults(results){
+		// convert string names back to intigers needed by DRP
+		const diceNotation = /[dD]\d+/i
+		results.forEach(result => {
+			if(typeof result.sides === "string" && result.sides.match(diceNotation)){
+				result.sides = parseInt(result.sides.substring(1))
+			}
+			result.rolls.forEach(roll => {
+				if(typeof roll.sides === "string" && roll.sides.match(diceNotation)){
+					roll.sides = parseInt(roll.sides.substring(1))
+				}
+			})
+		})
+
 		const rerolls = this.DRP.handleRerolls(results)
 		if(rerolls.length) {
 			this.onReroll(rerolls)

--- a/src/dicePicker/dicePicker.js
+++ b/src/dicePicker/dicePicker.js
@@ -147,7 +147,20 @@ class dicePicker {
   }
 
   handleResults(results){
-		// console.log(`results`, results)
+
+    // convert string names back to intigers needed by DRP
+    const diceNotation = /[dD]\d+/i
+    results.forEach(result => {
+      if(typeof result.sides === "string" && result.sides.match(diceNotation)){
+        result.sides = parseInt(result.sides.substring(1))
+      }
+      result.rolls.forEach(roll => {
+        if(typeof roll.sides === "string" && roll.sides.match(diceNotation)){
+          roll.sides = parseInt(roll.sides.substring(1))
+        }
+      })
+    })
+
 		const rerolls = this.DRP.handleRerolls(results)
 		if(rerolls.length) {
 			this.onReroll(rerolls)

--- a/src/displayResults/displayResults.js
+++ b/src/displayResults/displayResults.js
@@ -39,7 +39,15 @@ class DisplayResults {
 			}).flat()
 		}
 
-		let total = data.hasOwnProperty('value') ? data.value : rolls.reduce((val,roll) => val + roll.value,0)
+		let total = 0
+		if(data.hasOwnProperty('value')) {
+			total = data.value
+		} else { 
+			total = rolls.reduce((val,roll) => val + roll.value,0)
+			let modifier = data.reduce((val,roll) => val + roll.modifier,0)
+			total += modifier
+		}
+
 		total = isNaN(total) ? '...' : total
 		let resultString = ''
 


### PR DESCRIPTION
I've made the dice names more flexible in Dice-Box with this PR: https://github.com/3d-dice/dice-box/pull/60.
This builds on that so UI elements still work without having to make changes to the parser.